### PR TITLE
Add new holder's endpoint which get claims with given issuerURL

### DIFF
--- a/data/students.json
+++ b/data/students.json
@@ -1,11 +1,11 @@
 [
   {
      "jhed_id":"A1BCC1",
-     "first_name":"Geoffry",
-     "last_name":"Shemmin",
-     "email":"gshemmin0@cisco.com",
+     "first_name":"Matthew",
+     "last_name":"Green",
+     "email":"mgreen@cs.jhu.edu",
      "gender":"Male",
-     "birth_date":"20000302",
+     "birth_date":"19780401",
      "degree":"Doctoral",
      "program":"Security Informatics",
      "token":"fe7d9c51-5dcf-46dd-8bbc-ae9a0b716ee3"


### PR DESCRIPTION
Holder's getClaimsByIssuer is added in accommodating the "Get Claim" button of frontend. This frontend feature allows user to get claim with his/her selected issuer URL (localhost:8090 or localhost:1234).

Note: We need to update HEAD of holder-frontend submodule to latest commit once the front-end changes gets approved.